### PR TITLE
Chapter 3: Serve the website over HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# mkcert certificate
+localhost.p12
+
 # Compiled class file
 *.class
 

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -24,6 +24,12 @@ public class WebApp {
     }
 
     private void setupRateLimiting(int maxRequestsPerSecond) {
+
+        // server the development site over HTTPS
+        // - the certificate was generated via mkcert tool: https://github.com/FiloSottile/mkcert
+        //       mkcert -pkcs12 localhost
+        Spark.secure("localhost.p12", "changeit", null, null);
+
         var rateLimiter = RateLimiter.create(maxRequestsPerSecond);
         Spark.before(((request, response) -> {
             if (!rateLimiter.tryAcquire()) {


### PR DESCRIPTION
Certifcate generated in the project root folder: https://github.com/FiloSottile/mkcert#advanced-options
```
mkcert -pkcs12 localhost
```