### PR TITLE
Chapter3: Enable audit logging

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -1,6 +1,7 @@
 package com.manning.apisecurityinaction;
 
 import com.google.common.util.concurrent.RateLimiter;
+import com.manning.apisecurityinaction.controllers.AuditController;
 import com.manning.apisecurityinaction.controllers.UserController;
 import org.dalesbred.result.EmptyResultException;
 import org.json.JSONException;
@@ -50,6 +51,11 @@ public class WebApp {
         Spark.post("/users", userController::registerUser);
 
         Spark.before(userController::authenticate);
+
+        var auditController = new AuditController(database);
+        Spark.before((auditController::auditRequestStart));
+        Spark.afterAfter((auditController::auditRequestEnd));
+        Spark.get("/logs", auditController::readAuditLog);
 
         // In the book they first use after() but it should be afterAfter()
         // otherwise you'll get text/html content type for error responses

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/AuditController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/AuditController.java
@@ -1,0 +1,39 @@
+package com.manning.apisecurityinaction.controllers;
+
+import org.dalesbred.Database;
+import spark.Request;
+import spark.Response;
+
+/**
+ * Handles audit log operations.
+ * Audit logging is implemented as two filters:
+ * - before: unique audit_id is generated and request is logged
+ * - after: correlated audit_id is logged and processing is done
+ */
+public class AuditController {
+    private final Database database;
+
+    public AuditController(Database database) {
+        this.database = database;
+    }
+
+    public void auditRequestStart(Request request, Response response) {
+        database.withVoidTransaction(tx -> {
+            var auditId = database.findUniqueLong("SELECT NEXT VALUE FOR audit_id_seq");
+            request.attribute("audit_id", auditId);
+            database.updateUnique("INSERT INTO audit_log(audit_id, method, path, user_id, audit_time)" +
+                    " VALUES(?, ?, ?, ?, current_timestamp),",
+                    auditId, request.requestMethod(), request.pathInfo(), request.attribute("subject"));
+        });
+    }
+
+    public void auditRequestEnd(Request request, Response response) {
+        database.withVoidTransaction(tx -> {
+            var auditId = database.findUniqueLong("SELECT NEXT VALUE FOR audit_id_seq");
+            request.attribute("audit_id", auditId);
+            database.updateUnique("INSERT INTO audit_log(audit_id, method, path, status, user_id, audit_time)" +
+                    " VALUES(?, ?, ?, ?, ?, current_timestamp),",
+                    auditId, request.requestMethod(), request.pathInfo(), response.status(), request.attribute("subject"));
+        });
+    }
+}

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/AuditController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/AuditController.java
@@ -1,14 +1,24 @@
 package com.manning.apisecurityinaction.controllers;
 
 import org.dalesbred.Database;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import spark.Request;
 import spark.Response;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Handles audit log operations.
  * Audit logging is implemented as two filters:
  * - before: unique audit_id is generated and request is logged
  * - after: correlated audit_id is logged and processing is done
+ *
+ * This controller also exposes `readAuditLog` method which serves the requests to /logs endpoint
+ * and returns the latest 20 logs.
  */
 public class AuditController {
     private final Database database;
@@ -22,18 +32,40 @@ public class AuditController {
             var auditId = database.findUniqueLong("SELECT NEXT VALUE FOR audit_id_seq");
             request.attribute("audit_id", auditId);
             database.updateUnique("INSERT INTO audit_log(audit_id, method, path, user_id, audit_time)" +
-                    " VALUES(?, ?, ?, ?, current_timestamp),",
+                    " VALUES(?, ?, ?, ?, current_timestamp);",
                     auditId, request.requestMethod(), request.pathInfo(), request.attribute("subject"));
         });
     }
 
     public void auditRequestEnd(Request request, Response response) {
         database.withVoidTransaction(tx -> {
-            var auditId = database.findUniqueLong("SELECT NEXT VALUE FOR audit_id_seq");
-            request.attribute("audit_id", auditId);
+            // read audit_id set by `auditRequestStart`
+            var auditId = request.attribute("audit_id");
+            // Design note: I would probably implement it as UPDATE, not INSERT
+            // would add have end_timestamp column and set status
             database.updateUnique("INSERT INTO audit_log(audit_id, method, path, status, user_id, audit_time)" +
-                    " VALUES(?, ?, ?, ?, ?, current_timestamp),",
+                    " VALUES(?, ?, ?, ?, ?, current_timestamp);",
                     auditId, request.requestMethod(), request.pathInfo(), response.status(), request.attribute("subject"));
         });
     }
+
+    public JSONArray readAuditLog(Request request, Response response) {
+        var since = Instant.now().minus(1, ChronoUnit.HOURS);
+        var logs = database.findAll(AuditController::recordTojson,
+                "SELECT * FROM audit_log WHERE audit_time >= ? LIMIT 20",
+                since);
+        return new JSONArray(logs);
+    }
+
+    private static JSONObject recordTojson(ResultSet row) throws SQLException {
+        return new JSONObject()
+                .put("id", row.getLong("audit_id"))
+                .put("method", row.getString("method"))
+                .put("path", row.getString("path"))
+                .put("status", row.getString("status"))
+                .put("user", row.getString("user_id"))
+                .put("id", row.getLong("audit_id"));
+    }
+
+
 }

--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -29,3 +29,14 @@ CREATE TABLE users(
     pw_hash VARCHAR(255) NOT NULL
 );
 GRANT SELECT, INSERT On users TO natter_api_user;
+
+CREATE TABLE audit_log(
+    audit_id INT NULL,
+    method VARCHAR(10) NOT NULL,
+    path VARCHAR(100) NOT NULL,
+    user_id VARCHAR(30) NULL,
+    status INT NULL,
+    audit_time TIMESTAMP NOT NULL
+);
+CREATE SEQUENCE audit_id_seq;
+GRANT SELECT, INSERT ON audit_log TO natter_api_user;


### PR DESCRIPTION
AuditController has two methods for loging requests via before() and responses via afterAfter().

The logs are stored in `audit_log` table and can be read via `/logs` endpoint (last 20 records).