### PR TITLE
Chapter 5.2.2 - store Bearer tokens in the DB and reintroduce WWW-Authenticate header

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -5,13 +5,12 @@ import com.manning.apisecurityinaction.controllers.AuditController;
 import com.manning.apisecurityinaction.controllers.ModeratorController;
 import com.manning.apisecurityinaction.controllers.TokenController;
 import com.manning.apisecurityinaction.controllers.UserController;
-import com.manning.apisecurityinaction.token.CookieTokenStore;
+import com.manning.apisecurityinaction.token.DatabaseTokenStore;
 import org.dalesbred.result.EmptyResultException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import spark.Request;
 import spark.Response;
-import spark.Service;
 import spark.Spark;
 
 import com.manning.apisecurityinaction.controllers.SpaceController;
@@ -70,8 +69,10 @@ public class WebApp {
         var spaceController = new SpaceController(database);
 
         var userController = new UserController(database);
-        
-        var tokenController = new TokenController(new CookieTokenStore());
+
+        // chapter 5: replace CookieTokenStore with DatabaseTokenStore
+        // var tokenController = new TokenController(new CookieTokenStore());
+        var tokenController = new TokenController(new DatabaseTokenStore(database));
 
         // authentication
         Spark.before(userController::authenticate);

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/UserController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/UserController.java
@@ -78,10 +78,12 @@ public class UserController {
 
     public void requireAuthentication(Request request, Response response) {
         if (request.attribute("subject") == null) {
-            // Skip 'WWW-Authenticate' header to avoid ugly browser popups
-            // Note: technically, this is a violation of the RFC: https://datatracker.ietf.org/doc/html/rfc7235#section-3.1
-            // - however, this patter is widespread
+            // Chapter 4: Skip 'WWW-Authenticate' header to avoid ugly browser popups
+            //   Note: technically, this is a violation of the RFC: https://datatracker.ietf.org/doc/html/rfc7235#section-3.1
+            //   However, this patter is widespread
             // response.header("WWW-Authenticate", "Basic realm=\"/\", charset=\"UTF-8\"");
+            // Chapter 5: re-introduce WWW-Authenticate for Bearer tokens - see also TokenController
+            response.header("WWW-Authenticate", "Bearer");
             Spark.halt(401);
         }
     }

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/token/DatabaseTokenStore.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/token/DatabaseTokenStore.java
@@ -1,0 +1,66 @@
+package com.manning.apisecurityinaction.token;
+
+import org.dalesbred.Database;
+import org.json.JSONObject;
+import spark.Request;
+import java.security.SecureRandom;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+/**
+ * Simple implementation of TokenStore storing token attributes in session cookies.
+ */
+public class DatabaseTokenStore implements TokenStore {
+
+    private final Database database;
+    private final SecureRandom secureRandom;
+
+    public DatabaseTokenStore(Database database) {
+        this.database = database;
+        this.secureRandom = new SecureRandom();
+    }
+
+    // generate unguessable ID
+    private String randomId() {
+        var bytes = new byte[20];
+        secureRandom.nextBytes(bytes);
+        return Base64Url.encode(bytes);
+    }
+
+
+
+    @Override
+    public String create(Request request, Token token) {
+        var tokenId = randomId();
+        var attrs = new JSONObject(token.attributes()).toString();
+        database.updateUnique(
+                "INSERT INTO tokens(token_id, user_id, expiry, attributes) VALUES(?, ?, ?, ?)",
+                tokenId, token.username(), token.expiry(), attrs);
+        return tokenId;
+    }
+
+    @Override
+    public Optional<Token> read(Request request, String tokenId) {
+        return database.findOptional(this::readToken,
+                "SELECT user_id, expiry, attributes, FROM tokens WHERE token_id = ?", tokenId);
+    }
+
+    private Token readToken(ResultSet resultSet) throws SQLException {
+        var username = resultSet.getString(1);
+        var expiry = resultSet.getTimestamp(2).toInstant();
+        var json = new JSONObject(resultSet.getString(3));
+
+        var token = new Token(expiry, username);
+        for (String key : json.keySet()) {
+            token.attributes().put(key, json.getString(key));
+        }
+        return token;
+    }
+
+    @Override
+    public void revoke(Request request, String tokenId) {
+        database.update("DELETE FROM tokens WHERE token_id=?", tokenId);
+    }
+
+}

--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -59,3 +59,6 @@ CREATE TABLE tokens(
     attributes VARCHAR(4096) NOT NULL
 );
 GRANT SELECT, INSERT, DELETE ON tokens TO natter_api_user;
+
+-- to make sure regular cleanup of old tokens can be fast
+CREATE INDEX expired_token_idx ON tokens(expiry);


### PR DESCRIPTION
- instead of X-CSRF-Token we can use the standard Bearer authentication
- modify validateToken  in TokenController to work with "Bearer" auth scheme
  - use OAuth standard error codes OAuth & OpenID Connect ->  The OAuth 2.0 Authorization Framework: Bearer Token Usage: https://datatracker.ietf.org/doc/html/rfc6750
  - notice WWW-Authenticate (section 3) and notably 3.1 Error Codes (used in the book on p. 159/160)
- also update UserController#requireAuthentication