### PR TITLE
Chapter 5.2.4 - store tokens in local storage.

### DIFF
--- a/natter-api/src/main/resources/public/login.js
+++ b/natter-api/src/main/resources/public/login.js
@@ -18,7 +18,11 @@ function login(username, password) {
         res.json().then(json => {
           // note that you cannot use 'HttpOnly' cookie because JS needs to store this token in a cookie (for now)
           // but we can still use 'Secure' and 'SameSite'
-          document.cookie = 'csrfToken=' + json.token + ';Secure;SameSite=strict';
+
+          // Chapter 5.2.4 Stop the browser sending cookies
+          // document.cookie = 'csrfToken=' + json.token + ';Secure;SameSite=strict';
+          localStorage.setItem('token', json.token);
+
           // redirect to the main UI after the authentication is completed
           window.location.replace('/natter.html')
         })

--- a/natter-api/src/main/resources/public/natter.js
+++ b/natter-api/src/main/resources/public/natter.js
@@ -2,17 +2,23 @@ const apiUrl = 'https://localhost:4567'
 
 function createSpace(name, owner) {
   const data = {name, owner};
+
+  // NOT USED since Chapter 5.2.4
   // csrtToken cookie is set upon successful login - see login.js
-  const crsfToken = getCookie("csrfToken");
+  // const token = getCookie("csrfToken");
+  const token = localStorage.getItem('token');
 
   fetch(apiUrl  + '/spaces', {
     method: 'POST',
-    credentials: 'include',
+    // Chapter 5.2.4 Stop the browser sending cookies
+    // credentials: 'include',
     body: JSON.stringify(data),
     headers: {
       'Content-Type': 'application/json',
-      // make sure to include anti-CSRF token in the header
-      'X-CSRF-Token': crsfToken
+      // make sure to include anti-CSRF 4 in the header
+      // Chapter 5.2.4 Stop the browser sending cookies and use 'Authorization' header instead
+      // 'X-CSRF-Token': crsfToken
+      'Authorization': 'Bearer ' + token
     }
   })
     .then(response => {
@@ -41,6 +47,7 @@ function processFormSubmit(e) {
   return false; // prevent further event processing
 }
 
+// NOT USED since Chapter 5.2.4
 function getCookie(cookieName) {
   const cookieValue = document.cookie.split(';')
     .map(item => item.split('=')


### PR DESCRIPTION
`login.js` stores the token with `localStorage.setItem`.

`natter.js` gets the token with `localStorage.getItem`.
