### PR TITLE
Chapter 5.2.5 - Update CorsFilter.

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/CorsFilter.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/CorsFilter.java
@@ -25,7 +25,8 @@ public class CorsFilter implements Filter {
         var origin = request.headers("Origin");
         if (origin != null && allowedOrigins.contains(origin)) {
             response.header("Access-Control-Allow-Origin", origin);
-            response.header("Access-Control-Allow-Credentials", "true");
+            // Update chapter 5: this is only needed for cookies
+            // response.header("Access-Control-Allow-Credentials", "true");
             response.header("Vary", "origin");
         }
 
@@ -36,7 +37,9 @@ public class CorsFilter implements Filter {
                 Spark.halt(403);
             }
 
-            response.header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-CSRF-Token");
+            // Update chapter 5: no need for whitelisting X-CSRF-Token anymore since we use tokens
+            // response.header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-CSRF-Token");
+            response.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
             response.header("Access-Control-Allow-Methods", "GET, POST, DELETE");
             // Again, CORS doesn't prescribe a status code but it's common to return 204
             Spark.halt(204);

--- a/natter-api/src/main/resources/public/login.js
+++ b/natter-api/src/main/resources/public/login.js
@@ -7,7 +7,8 @@ function login(username, password) {
   fetch(apiUrl + '/sessions', {
     method: 'POST',
     // we must include credentials to make sure the browser sets cookies for CORS responses
-    credentials: 'include',
+    // UPDATE: chapter 5 uses tokens and we must remove this (p.167)
+    // credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': credentials

--- a/natter-api/src/main/resources/public/logout.js
+++ b/natter-api/src/main/resources/public/logout.js
@@ -5,11 +5,13 @@ function logout() {
 
   fetch(apiUrl  + '/sessions', {
     method: 'DELETE',
-    credentials: 'include',
+    // UPDATE: chapter 5 uses tokens and we must remove this (p.167)
+    // credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       // make sure to include anti-CSRF token in the header
-      'X-CSRF-Token': crsfToken
+      // Chapter 5: not using cookies for authentication anymore
+      // 'X-CSRF-Token': crsfToken
     }
   })
     .then(response => {


### PR DESCRIPTION
No need to allow sending credentials anymore.

Because we no longer use cookies, we don't need the browser to automatically send them
- => remove Access-Control-Allow-Credentials header

login.js (and possibly logout.js ) - remove this:
```
credentials: 'include'
```
- otherwise browser blocks the request completely (because you ommited the Access-Control-Allow-Credentials header) 
  - ![image](https://user-images.githubusercontent.com/1083629/214780789-3a088cae-aab2-40bb-9e73-6db3d6ffed3f.png)

- you can test this by running separate instance: https://localhost:9999/login.html 
```
# but first you need to create the user to be able to login
curl -d '{"username":"demo","password":"password"}' -H 'Content-Type: application/json' https://localhost:4567/users
```
	- 
- Test logout too: https://localhost:9999/logout.html
	- I think they forgot to update logout.js in the book