### PR TITLE
Chapter 6.1 - Protect basic JsonTokenStore with HmacTokenStore

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -7,6 +7,8 @@ import com.manning.apisecurityinaction.controllers.TokenController;
 import com.manning.apisecurityinaction.controllers.UserController;
 import com.manning.apisecurityinaction.token.DatabaseTokenStore;
 import com.manning.apisecurityinaction.token.HmacTokenStore;
+import com.manning.apisecurityinaction.token.JsonTokenStore;
+import com.manning.apisecurityinaction.token.TokenStore;
 import org.dalesbred.result.EmptyResultException;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -81,7 +83,11 @@ public class WebApp {
 
         // chapter 5: replace CookieTokenStore with DatabaseTokenStore
         // var tokenController = new TokenController(new CookieTokenStore());
-        var tokenStore = new HmacTokenStore(new DatabaseTokenStore(database), getHmacSecretKey());
+
+        // Chapter 6: replace DatabaseTokenStore with JsonTokenStore
+        // var tokenStore = new HmacTokenStore(new DatabaseTokenStore(database), getHmacSecretKey());
+        var tokenStore = new HmacTokenStore(new JsonTokenStore(), getHmacSecretKey());
+
         var tokenController = new TokenController(tokenStore);
 
         // authentication


### PR DESCRIPTION
This prevents spoofing and tampering (see STRIDE).

Test

```
curl -d '{"username":"demo","password":"password"}' -H 'Content-Type: application/json' https://localhost:4567/users
{"username":"demo"}%


 curl -udemo:password -X POST -H 'Content-Type: application/json' https://localhost:4567/sessions
{"token":"eyJzdWIiOiJkZW1vIiwiZXhwIjoxNjc1ODYzODE2LCJhdHRycyI6e319.mCKJlE-iYBnSBsThvMv5GuhWWMuO6YyfMyrb8zLVcYw"}%


 curl -i -H 'Authorization: Bearer eyJzdWIiOiJkZW1vIiwiZXhwIjoxNjc1ODYzODE2LCJhdHRycyI6e319.mCKJlE-iYBnSBsThvMv5GuhWWMuO6YyfMyrb8zLVcYw' -H 'Content-Type: application/json' -d '{"name": "test space", "owner": "demo"}' https://localhost:4567/spaces
HTTP/1.1 201 Created
...
{"name":"test space","uri":"/spaces/1"}%
```