### PR TITLE
Chapter 6.2 - Generate and verify signed JWT tokens.

### DIFF
--- a/natter-api/pom.xml
+++ b/natter-api/pom.xml
@@ -66,6 +66,12 @@
       <artifactId>scrypt</artifactId>
       <version>1.4.0</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt -->
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>9.30.1</version>
+    </dependency>
   </dependencies>
 
 

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/Main.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/Main.java
@@ -1,5 +1,6 @@
 package com.manning.apisecurityinaction;
 
+import com.nimbusds.jose.JOSEException;
 import org.dalesbred.Database;
 import org.h2.jdbcx.JdbcConnectionPool;
 
@@ -14,7 +15,7 @@ import java.security.cert.CertificateException;
 
 public class Main {
 
-    public static void main(String[] args) throws URISyntaxException, IOException, UnrecoverableKeyException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
+    public static void main(String[] args) throws URISyntaxException, IOException, UnrecoverableKeyException, CertificateException, KeyStoreException, NoSuchAlgorithmException, JOSEException {
         // first populate the schema with elevated permissions
         createTables(Database.forDataSource(JdbcConnectionPool.create("jdbc:h2:mem:natter", "natter", "password")));
 

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/token/SignedJwtTokenStore.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/token/SignedJwtTokenStore.java
@@ -1,0 +1,76 @@
+package com.manning.apisecurityinaction.token;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import spark.Request;
+
+import java.sql.Date;
+import java.text.ParseException;
+import java.util.Optional;
+
+public class SignedJwtTokenStore implements TokenStore {
+
+    private final JWSSigner signer;
+    private final JWSVerifier verifier;
+    private final JWSAlgorithm algorithm;
+    private final String audience;
+    private final JWSHeader header;
+
+    public SignedJwtTokenStore(JWSSigner signer, JWSVerifier verifier, JWSAlgorithm algorithm, String audience) {
+        this.signer = signer;
+        this.verifier = verifier;
+        this.audience = audience;
+        this.algorithm = algorithm;
+        // I have this here instead of both create and read methods because it's immutable and only depends on algorithm
+        this.header = new JWSHeader(algorithm);
+    }
+
+    @Override
+    public String create(Request request, Token token) {
+        var claimsSet = new JWTClaimsSet.Builder()
+                .subject(token.username())
+                .audience(this.audience)
+                .expirationTime(Date.from(token.expiry()))
+                .claim("attrs", token.attributes())
+                .build();
+        var jwt = new SignedJWT(this.header, claimsSet);
+        try {
+            jwt.sign(this.signer);
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Optional<Token> read(Request request, String tokenId) {
+        try {
+            // first parse the Compact Serialization Format
+            var jwt = SignedJWT.parse(tokenId);
+            if (!jwt.verify(this.verifier)) {
+                throw new JOSEException("Invalid signature");
+            }
+            var claims = jwt.getJWTClaimsSet();
+            if (!claims.getAudience().contains(this.audience)) {
+                throw new JOSEException("Incorrect audience");
+            }
+
+            var token = new Token(claims.getExpirationTime().toInstant(), claims.getSubject());
+            var attrs = claims.getJSONObjectClaim("attrs");
+            attrs.forEach((k,v) -> token.attributes().put(k, (String) v));
+            return Optional.of(token);
+        } catch (ParseException | JOSEException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void revoke(Request request, String tokenId) {
+
+    }
+}


### PR DESCRIPTION
Introduces new SignedJwtTokenStore class which is an implementation of TokenStore. Unlike DatabaseTokenStore, it doesn't store anything in a persistent storage. Instead, it only creates a signed version of the Token and then it verifies it.

It uses the same macKey as HmacTokenStore - notice the usage of MACSigner and MACVerifier classes.

Also notice how the read method checks the audience.