### PR TITLE
Chapter 7.4.1 Add OAuth2TokenStore.

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -9,6 +9,7 @@ import com.manning.apisecurityinaction.token.DatabaseTokenStore;
 import com.manning.apisecurityinaction.token.EncryptedJwtTokenStore;
 import com.manning.apisecurityinaction.token.EncryptedTokenStore;
 import com.manning.apisecurityinaction.token.JsonTokenStore;
+import com.manning.apisecurityinaction.token.OAuth2TokenStore;
 import com.nimbusds.jose.JOSEException;
 import org.dalesbred.result.EmptyResultException;
 import org.json.JSONException;
@@ -23,6 +24,7 @@ import org.dalesbred.Database;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -104,7 +106,14 @@ public class WebApp {
 
         // chapter 6.3.4 Replacing EncryptedTokenStore with EncryptedJwtTokenStore
         // var tokenStore = new EncryptedTokenStore(new JsonTokenStore(), getEncKey());
-        var tokenStore = new EncryptedJwtTokenStore((SecretKey) getEncKey());
+        // chapter 7.4 - replacing EncryptedJwtTokenStore with OAuth2TokenStore (p. 243)
+        // var tokenStore = new EncryptedJwtTokenStore((SecretKey) getEncKey());
+        var introspectionEndpoint = URI.create("http://as.example.com:8080/oauth2/introspect");
+        // these are the client credentials you defined when configuring ForgeRok OAuth server
+        // - see Applications -> Oauth 2.0 -> Clients: http://as.example.com:8080/XUI/?realm=/#realms/%2F/applications-oauth2
+        var clientId = "test";
+        var clientSecret = "changeit";
+        var tokenStore = new OAuth2TokenStore(introspectionEndpoint, clientId, clientSecret);
 
         var tokenController = new TokenController(tokenStore);
 

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/oauth/Utils.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/oauth/Utils.java
@@ -1,0 +1,24 @@
+package com.manning.apisecurityinaction.oauth;
+
+import java.nio.charset.StandardCharsets;
+
+public class Utils {
+
+    String addPkceChallengeCode(spark.Request request, String authorizeRequest) throws Exception {
+        var secureRandom = new java.security.SecureRandom();
+        var encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+
+        // generate the code verifier
+        var verifierBytes = new byte[32];
+        secureRandom.nextBytes(verifierBytes);
+        var verifier = encoder.encodeToString(verifierBytes);
+
+        // store it in the session
+        request.session(true).attribute("verifier", verifier);
+
+        // generate SHA256 of the code verifier and add it as a request param to the redirect url
+        var sha256 = java.security.MessageDigest.getInstance("SHA-256");
+        var challenge = encoder.encodeToString(sha256.digest(verifier.getBytes(StandardCharsets.UTF_8)));
+        return authorizeRequest + "&code_challenge=" + challenge + "&code_challenge_method=S256";
+    }
+}

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/token/OAuth2TokenStore.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/token/OAuth2TokenStore.java
@@ -1,0 +1,98 @@
+package com.manning.apisecurityinaction.token;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.json.JSONObject;
+import spark.Request;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * This is a TokenStore implementation that uses OAuth2 Token Introspection Endpoint
+ * to validate access tokens.
+ */
+public class OAuth2TokenStore implements SecureTokenStore {
+
+    private final URI introspectionEndpoint;
+    private final String authorization;
+    private final HttpClient httpClient;
+
+    public OAuth2TokenStore(URI introspectionEndpoint, String clientId, String clientSecret) {
+        this.introspectionEndpoint = introspectionEndpoint;
+
+        var credentials = URLEncoder.encode(clientId, UTF_8) + ":" + URLEncoder.encode(clientSecret, UTF_8);
+        this.authorization = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(UTF_8));
+
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    @Override
+    public Optional<Token> read(Request request, String tokenId) {
+        // Notice we validate the token format to adhere to the "always validate all inputs" principle (chapter 2, p.50)
+        if (!tokenId.matches("[\\x20-\\x7E]{1,1024}")) {
+            return Optional.empty();
+        }
+
+        // Another principle: properly encoded parameters
+        var form = "token=" + URLEncoder.encode(tokenId, UTF_8) + "&token_type_hint=access_token";
+        var httpRequest = HttpRequest.newBuilder()
+                .uri(introspectionEndpoint)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                // use client credentials to authenticate against introspection endpoint
+                .header("Authorization", authorization)
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build();
+
+        try {
+            var httpResponse = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            if (httpResponse.statusCode() == 200) {
+                var json = new JSONObject(httpResponse.body());
+                if (json.getBoolean("active")) {
+                    return processResponse(json);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Token> processResponse(JSONObject introspectionResponse) {
+        var expiry = Instant.ofEpochSecond(introspectionResponse.getLong("exp"));
+        var subject = introspectionResponse.getString("sub");
+        var token = new Token(expiry, subject);
+        token.attributes().put("scope", introspectionResponse.getString("scope"));
+        token.attributes().put("client_id", introspectionResponse.optString("client_id"));
+        return Optional.of(token);
+    }
+
+
+    /*
+       By throwing exception in #create and #revoke methods
+       we effectively disable login and logout
+       and force clients to obtain access tokens from AS.
+     */
+
+    @Override
+    public String create(Request request, Token token) {
+        throw new UnsupportedOperationException("Obtain access token from AS!");
+    }
+
+
+    @Override
+    public void revoke(Request request, String tokenId) {
+        throw new UnsupportedOperationException("Obtain access token from AS!");
+    }
+}


### PR DESCRIPTION
This implements a new token store using OAuth2 tokens.

It uses "introspection endpoint" which is in our case ForgeRock Access Management product running in a docker container on the same machine (see Appendinx A for instructions). We use the introspection endpoint to validate tokens supplied by the client. The endpoint should respond with 200 and "active" field _true_ if the token is valid.

If that holds, we extract some more information from the token such as "exp", "sub", "scope", and "client_id". Note that all these fields are optional (see Table 7.1 on p. 242) and they might be missing in some OAuth2 AS implementations.