### PR TITLE
Chapter 8.1 Users and Groups - separating permissions and using Hydra OAuth server

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/WebApp.java
@@ -108,11 +108,14 @@ public class WebApp {
         // var tokenStore = new EncryptedTokenStore(new JsonTokenStore(), getEncKey());
         // chapter 7.4 - replacing EncryptedJwtTokenStore with OAuth2TokenStore (p. 243)
         // var tokenStore = new EncryptedJwtTokenStore((SecretKey) getEncKey());
-        var introspectionEndpoint = URI.create("http://as.example.com:8080/oauth2/introspect");
-        // these are the client credentials you defined when configuring ForgeRok OAuth server
-        // - see Applications -> Oauth 2.0 -> Clients: http://as.example.com:8080/XUI/?realm=/#realms/%2F/applications-oauth2
-        var clientId = "test";
-        var clientSecret = "changeit";
+        // See HTTP API documentation: https://github.com/ory/hydra#http-api-documentation -> https://www.ory.sh/docs/hydra/reference/api#tag/oAuth2/operation/introspectOAuth2Token 
+        var introspectionEndpoint = URI.create("http://127.0.0.1:4445/admin/oauth2/introspect");
+        // these are the client credentials you defined when configuring OAuth server
+        // - I do not use ForgeRock because it's such a PITA to reconfigure every time I kill it
+        // - Instead, I use hydra: https://www.ory.sh/docs/hydra/5min-tutorial
+        // - NOTE: create a client  capable of "Authorization Code" grant
+        var clientId = "44be63d2-fc23-4256-baab-fc4559ffffc3";
+        var clientSecret = "AILIDtOIvPGGRZij140fVovpeB";
         var tokenStore = new OAuth2TokenStore(introspectionEndpoint, clientId, clientSecret);
 
         var tokenController = new TokenController(tokenStore);

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
@@ -25,7 +25,9 @@ public class SpaceController {
      * Permissions are: 'r' for "read", 'w' for "write", 'd' for "delete".
      */
     private void addPermissions(long spaceId, String username, String permissions) {
-        database.updateUnique("INSERT INTO permissions(space_id, user_id, perms) VALUES(?, ?, ?)",
+        // NOTE: the table name was changed in chapter 8.1 to `user_permissions`, instead of former `permissions`
+        // There's still the `permissions` view but we don't want to use that.
+        database.updateUnique("INSERT INTO user_permissions(space_id, user_id, perms) VALUES(?, ?, ?)",
                     spaceId, username, permissions);
     }
 
@@ -42,7 +44,8 @@ public class SpaceController {
         if (spaceName.length() > 255) {
             throw new IllegalArgumentException("space name too long");
         }
-        if (!owner.matches("[a-zA-Z][a-zA-Z0-9]{1,29}")) {
+
+        if (!owner.matches(UserController.USERNAME_PATTERN.pattern())) {
             // note that echoing back the username might not be the best idea - see later in the book
             throw new IllegalArgumentException("invalid username");
         }

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/UserController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/UserController.java
@@ -19,7 +19,10 @@ import java.util.regex.Pattern;
  */
 public class UserController {
 
-    private static final Pattern USERNAME_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9]{1,29}");
+    // In the book they use stricter validation but I use Hydra sample server
+    // that uses `foo@bar.com` username
+    // see https://www.ory.sh/docs/hydra/5min-tutorial
+    public static final Pattern USERNAME_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9@.]{1,29}");
     private final Database database;
 
     public UserController(Database database) {

--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -62,3 +62,38 @@ GRANT SELECT, INSERT, DELETE ON tokens TO natter_api_user;
 
 -- to make sure regular cleanup of old tokens can be fast
 CREATE INDEX expired_token_idx ON tokens(expiry);
+
+-- Ch8 (p. 269/270) - adding groups of users
+-- NOTE: I added another table 'groups' to make groups more explicit and decoupled
+CREATE TABLE groups(
+    group_id VARCHAR(30) PRIMARY KEY
+);
+CREATE TABLE group_members(
+    group_id VARCHAR(30) NOT NULL REFERENCES groups(group_id),
+    user_id VARCHAR(30) NOT NULL REFERENCES users(user_id));
+CREATE INDEX group_member_user_idx ON group_members(user_id);
+CREATE TABLE user_permissions(
+    space_id INT NOT NULL REFERENCES spaces(space_id),
+    user_id VARCHAR(30) NOT NULL REFERENCES users(user_id),
+    -- perms are: 'r' for "read", 'w' for "write", 'd' for "delete"
+    perms VARCHAR(3) NOT NULL,
+    PRIMARY KEY (space_id, user_id)
+);
+GRANT SELECT, INSERT ON user_permissions TO natter_api_user;
+
+CREATE TABLE group_permissions(
+    space_id INT NOT NULL REFERENCES spaces(space_id),
+    group_id VARCHAR(30) NOT NULL REFERENCES groups(group_id),
+    -- perms are: 'r' for "read", 'w' for "write", 'd' for "delete"
+    perms VARCHAR(3) NOT NULL,
+    PRIMARY KEY (space_id, group_id)
+);
+GRANT SELECT, INSERT ON group_permissions TO natter_api_user;
+
+-- first, I need to rename the existing permissions table ...
+ALTER TABLE permissions RENAME TO permissions_old;
+-- ... then I can create a new 'permissions' view
+CREATE VIEW permissions(space_id, user_or_group_id, perms) AS
+    SELECT space_id, user_id, perms FROM user_permissions
+    UNION ALL
+    SELECT space_id, group_id, perms FROM group_permissions;


### PR DESCRIPTION
See also Hydra tutorial: https://www.ory.sh/docs/hydra/5min-tutorial.

In summary, this splits permissions table into `user_permissions` and `group_permissions`. `permissions` is now a view that combines those two tables. Existing INSERT in SpaceController has to be changed to insert into user_permissions table.

## Example of getting a token and using it to create a new Space via API

### Hydra - setup and get OAuth token

```
code_client=$(hydra create client \
    --endpoint http://127.0.0.1:4445 \
    --grant-type authorization_code,refresh_token \
    --response-type code,id_token \
    --format json \
    --scope openid --scope offline --scope create_space --scope post_message --scope list_messages --scope read_message --scope delete_message --scope add_member \
    --redirect-uri http://127.0.0.1:5566/callback)

code_client_id=$(echo $code_client | jq -r '.client_id')
code_client_secret=$(echo $code_client | jq -r '.client_secret')

hydra perform authorization-code \
    --client-id $code_client_id \
    --client-secret $code_client_secret \
    --endpoint http://127.0.0.1:4444/ \
    --port 5566 \
    --scope openid --scope offline --scope create_space --scope post_message --scope list_messages --scope read_message --scope delete_message --scope add_member
```

Then login and approve the access via http://127.0.0.1:5566
![image](https://github.com/jumarko/api-security-in-action/assets/1083629/f6c4e784-7bde-46f1-8bfe-0e7bc3c2da4d)


### Natter API call

```
curl -d '{"username":"foo@bar.com","password":"password"}' -H 'Content-Type: application/json' https://localhost:4567/users

curl -v -H 'Content-Type: application/json' -H 'Authorization: Bearer ory_at_gwjfta__SC6wX6aSFsLOLadlggiHRsHXI6quYkfVabg.k67dUqnK--oP1gvSnGTIPRkR-dNf4n8mkFv1EnsJdLI' -d '{"name": "test", "owner": "foo@bar.com"}' https://localhost:4567/spaces
...
{"name":"test","uri":"/spaces/1"}%
```