### PR TITLE
Ch 8.1.2 - Update SpaceController to use roles instead of permissions.

### DIFF
--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -109,3 +109,11 @@ INSERT INTO role_permissions(role_id, perms)
            ('member', 'rw'),
            ('observer', 'r');
 GRANT SELECT ON role_permissions TO natter_api_user;
+
+CREATE TABLE user_roles(
+    space_id INT NOT NULL REFERENCES spaces(space_id),
+    user_id VARCHAR(30) NOT NULL REFERENCES users(user_id),
+    role_id VARCHAR(30) NOT NULL REFERENCES role_permissions(role_id),
+    -- this restrics 1 user to a single role, for more roles remove this key and define an index instead
+    PRIMARY KEY (space_id, user_id)
+);

--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -98,3 +98,14 @@ CREATE VIEW permissions(space_id, user_or_group_id, perms) AS
     UNION ALL
     SELECT space_id, group_id, perms FROM group_permissions;
 GRANT SELECT ON permissions TO natter_api_user;
+
+CREATE TABLE role_permissions(
+    role_id VARCHAR(30) NOT NULL PRIMARY KEY,
+    perms VARCHAR(3) NOT NULL
+)
+INSERT INTO role_permissions(role_id, perms)
+    VALUES ('owner', 'rwd'),
+           ('moderator', 'rd'),
+           ('member', 'rw'),
+           ('observer', 'r');
+GRANT SELECT ON role_permissions TO natter_api_user;


### PR DESCRIPTION
The crucial changes are in the `createSpace` and `addMember` methods.
- createSpace assigns "owner" role to the owner of the space
- addMember parses "role" from the request and sets the appropriate role (defaulting to "member")
  - the role is also validated to be one of 'owner', 'moderator', 'member', 'observer'.
