### PR TITLE
Ch 8.2.3 checking permissions by using roles.

### DIFF
--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -102,7 +102,7 @@ GRANT SELECT ON permissions TO natter_api_user;
 CREATE TABLE role_permissions(
     role_id VARCHAR(30) NOT NULL PRIMARY KEY,
     perms VARCHAR(3) NOT NULL
-)
+);
 INSERT INTO role_permissions(role_id, perms)
     VALUES ('owner', 'rwd'),
            ('moderator', 'rd'),


### PR DESCRIPTION
There's new UserControler#lookupPermissions method that selects user's permissions based on their role and stores this in the "perms" request attribute.

Subsequently, this permissions are used in `requirePermissions` method and may be used elsewhere multiple times without worrying about efficiency.