### PR TITLE
Ch 9.2.2/3 Capability URIs for Natter API spaces.

### DIFF
--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/CapabilityController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/CapabilityController.java
@@ -1,0 +1,51 @@
+package com.manning.apisecurityinaction.controllers;
+
+import static java.time.Instant.now;
+
+import com.manning.apisecurityinaction.token.SecureTokenStore;
+import com.manning.apisecurityinaction.token.TokenStore;
+import spark.Request;
+import spark.Response;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Capability-based access control (chapter 9).
+ * This controller creates a capability-URI by reusing an existing TokenStore implementation
+ * (you can use any secure TokenStore impl. - in this chapter, we'll use DatabaseTokenStore)
+ * to create a token encoding two specific attributes, that is 'path' and 'perms' (permissions).
+ * The token is stored in the standard 'access_token' query parameter (see RFC 6750).
+ */
+public class CapabilityController {
+    private final SecureTokenStore tokenStore;
+
+    public CapabilityController(SecureTokenStore tokenStore) {
+        this.tokenStore = tokenStore;
+    }
+
+    public URI createURI(Request request, String path, String perms, Duration expiryDuration) {
+         // NOTE: username is null because capability URIs don't have any associated username (they can be shared)
+        var token = new TokenStore.Token(now().plus(expiryDuration), null);
+        token.attributes().put("path", path);
+        token.attributes().put("perms", perms);
+        final String tokenId = tokenStore.create(request, token);
+        var uri = URI.create(request.uri());
+        return uri.resolve(path + "?access_token=" + tokenId);
+    }
+
+    public void lookupPermissions(Request request, Response response) {
+        var tokenId = request.queryParams("access_token");
+        // no token means no access granted
+        if (tokenId == null) { return; }
+
+        tokenStore.read(request, tokenId).ifPresent(token -> {
+            var tokenPath = token.attributes().get("path");
+            if (Objects.equals(tokenPath, request.pathInfo())) {
+                // if paths match the token is for this resource - we can set request permissions to the perms encoded in the token
+                request.attribute("perms", token.attributes().get("perms"));
+            }
+        });
+    }
+}

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
@@ -83,9 +83,19 @@ public class SpaceController {
             var expiry = Duration.ofDays(1000000); // very long duration as the URI is the only way to access the space from now on
             var uri = capabilityController.createURI(request, spaceUri, "rwd", expiry);
 
+            // ch 9.2.3 (p. 308/9) - returning more capability URIs to allow the client to access rome real space resources like messages
+            var messagesUri = capabilityController.createURI(request, spaceUri + "/messages", "rwd", expiry);
+            var messagesReadWriteUri = capabilityController.createURI(request, spaceUri + "/messages", "rw", expiry);
+            var messagesReadOnlyUri = capabilityController.createURI(request, spaceUri + "/messages", "rw", expiry);
+
             response.status(201);
             response.header("Location", uri.toASCIIString());
-            return new JSONObject().put("name", spaceName).put("uri", uri);
+            return new JSONObject()
+                    .put("name", spaceName)
+                    .put("uri", uri)
+                    .put("messages-rwd", messagesUri)
+                    .put("messages-rw", messagesReadWriteUri)
+                    .put("messages-r", messagesReadOnlyUri);
         });
 
     }

--- a/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
+++ b/natter-api/src/main/java/com/manning/apisecurityinaction/controllers/SpaceController.java
@@ -5,9 +5,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import spark.Request;
 import spark.Response;
-import spark.utils.StringUtils;
 
-import java.sql.SQLException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -18,9 +17,15 @@ public class SpaceController {
     private static final Set<String> DEFINED_ROLES = Set.of("owner", "moderator", "member", "observer");
 
     private final Database database;
+    private final CapabilityController capabilityController;
 
     public SpaceController(Database database) {
+        this(database, null);
+    }
+
+    public SpaceController(Database database, CapabilityController capabilityController) {
         this.database = database;
+        this.capabilityController = capabilityController;
     }
 
     /**
@@ -53,7 +58,7 @@ public class SpaceController {
             throw new IllegalArgumentException("invalid username");
         }
 
-        // my custom additon for better error message in the browser
+        // my custom addition for better error message in the browser
         var space = database.findOptional(String.class, "SELECT name from spaces WHERE name = ?", spaceName);
         if (space.isPresent()) {
             throw new IllegalArgumentException("Space already exists! You must provide a unique space name");
@@ -69,13 +74,18 @@ public class SpaceController {
             // give full permissions to the space owner
             // Chapter 8.1.2 - full permissions replaced with the owner role
             // addPermissions(spaceId, owner, "rwd");
-            database.updateUnique("INSERT INTO user_roles(space_id, user_id, role_id) " +
-                    "VALUES(?,?,?)", spaceId, owner, "owner");
+
+            // Chapter 9.2.2 (p. 305/6) - Capability URIs
+            // - no need to insert into user_roles anymore because we will be using capabilities for access control
+//            database.updateUnique("INSERT INTO user_roles(space_id, user_id, role_id) " +
+//                    "VALUES(?,?,?)", spaceId, owner, "owner");
+            var spaceUri = "/spaces/" + spaceId;
+            var expiry = Duration.ofDays(1000000); // very long duration as the URI is the only way to access the space from now on
+            var uri = capabilityController.createURI(request, spaceUri, "rwd", expiry);
 
             response.status(201);
-            var spaceUri = "/spaces/" + spaceId;
-            response.header("Location", spaceUri);
-            return new JSONObject().put("name", spaceName).put("uri", spaceUri);
+            response.header("Location", uri.toASCIIString());
+            return new JSONObject().put("name", spaceName).put("uri", uri);
         });
 
     }

--- a/natter-api/src/main/resources/schema.sql
+++ b/natter-api/src/main/resources/schema.sql
@@ -53,7 +53,8 @@ GRANT SELECT, INSERT ON permissions TO natter_api_user;
 
 CREATE TABLE tokens(
     token_id VARCHAR(100) PRIMARY KEY,
-    user_id VARCHAR(30) NOT NULL,
+    -- NOT NULL constraint removed in Chapter 9 (p. 305) to support capability-based URIs/tokens
+    user_id VARCHAR(30),
     expiry TIMESTAMP  NOT NULL,
     -- attributes are a JSON text
     attributes VARCHAR(4096) NOT NULL
@@ -72,6 +73,7 @@ CREATE TABLE group_members(
     group_id VARCHAR(30) NOT NULL REFERENCES groups(group_id),
     user_id VARCHAR(30) NOT NULL REFERENCES users(user_id));
 CREATE INDEX group_member_user_idx ON group_members(user_id);
+GRANT SELECT, INSERT ON group_members TO natter_api_user;
 CREATE TABLE user_permissions(
     space_id INT NOT NULL REFERENCES spaces(space_id),
     user_id VARCHAR(30) NOT NULL REFERENCES users(user_id),


### PR DESCRIPTION
We implement capability URIs via new class CapabilityController. That has createURI method for creating capability URIs (from within SpaceController) and lookupPermissions method for parsing tokens from capability URIs and validating them (used via Spark filters for /spaces/<id>/* routes).

With only a space URI, the client cannot do much - we don't even have a resource
for showing space details.
There are messages, however, the client cannot access the
since it cannot easily construct the uri by appending '/messages'.

In the spirit of HATEOS, we need to include all the relevant links in the response!

We actually return 3 different messages links:
- "messages" for full access
- "messages-rw" for read-write (no delete) access
- "messages-r" for read-only access